### PR TITLE
metrics: fix the issue of special characters being escaped in passwords

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -140,7 +140,7 @@ func (ms *Metrics) createCollector(config ExporterConfig) (prometheus.Collector,
 	switch config.Type {
 
 	case model.ApplicationTypePostgres:
-		userPass := url.UserPassword(config.Credentials.Username, config.Credentials.Password)
+		userPass := fmt.Sprintf("%s:%s", config.Credentials.Username, config.Credentials.Password)
 		query := url.Values{}
 		query.Set("connect_timeout", "1")
 		query.Set("statement_timeout", strconv.Itoa(int(timeout.Milliseconds())))
@@ -157,7 +157,7 @@ func (ms *Metrics) createCollector(config ExporterConfig) (prometheus.Collector,
 		return collector, func() { _ = collector.Close() }, nil
 
 	case model.ApplicationTypeMysql:
-		userPass := url.UserPassword(config.Credentials.Username, config.Credentials.Password)
+		userPass := fmt.Sprintf("%s:%s", config.Credentials.Username, config.Credentials.Password)
 		query := url.Values{}
 		query.Set("timeout", fmt.Sprintf("%dms", timeout.Milliseconds()))
 		tls := config.Params["tls"]

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -140,7 +140,7 @@ func (ms *Metrics) createCollector(config ExporterConfig) (prometheus.Collector,
 	switch config.Type {
 
 	case model.ApplicationTypePostgres:
-		userPass := fmt.Sprintf("%s:%s", config.Credentials.Username, config.Credentials.Password)
+		userPass := url.UserPassword(config.Credentials.Username, config.Credentials.Password)
 		query := url.Values{}
 		query.Set("connect_timeout", "1")
 		query.Set("statement_timeout", strconv.Itoa(int(timeout.Milliseconds())))


### PR DESCRIPTION
Fixed: #2 

Here are the reasons
```go
	userPass1 := url.UserPassword("root", "123%abc")
	fmt.Printf("userPass1: %s\n", userPass1)

	userPass2 := fmt.Sprintf("%s:%s", "root", "123%abc")
	fmt.Printf("userPass2: %s\n", userPass2)

	// userPass1: root:123%25abc
	// userPass2: root:123%abc
```