### PR TITLE
Add custom CA support for TLS verification

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -1,12 +1,38 @@
 package common
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 
+	"github.com/coroot/coroot-cluster-agent/flags"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog"
 )
+
+func TlsConfig() *tls.Config {
+	cfg := &tls.Config{InsecureSkipVerify: *flags.InsecureSkipVerify}
+	if *flags.CAFile != "" {
+		ca, err := os.ReadFile(*flags.CAFile)
+		if err != nil {
+			klog.Fatalln(err)
+			return cfg
+		}
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			klog.Warningln("failed to load system cert pool, starting with empty pool:", err)
+			pool = x509.NewCertPool()
+		}
+		if !pool.AppendCertsFromPEM(ca) {
+			klog.Fatalf("failed to parse CA from %s", *flags.CAFile)
+		}
+		cfg.RootCAs = pool
+	}
+	return cfg
+}
 
 func AuthHeaders(apiKey string) map[string]string {
 	return map[string]string{

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -34,7 +33,7 @@ func NewUpdater() (*Updater, error) {
 		httpClient: &http.Client{
 			Timeout: *flags.ConfigUpdateTimeout,
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: *flags.InsecureSkipVerify},
+				TLSClientConfig: common.TlsConfig(),
 			},
 		},
 	}

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -23,6 +23,7 @@ var (
 	KubeStateMetricsListenAddress = kingpin.Flag("kube-state-metrics-listen-address", "Listen address for the kube-state-metrics endpoint").Default("127.0.0.1:10303").Envar("KUBE_STATE_METRICS_LISTEN_ADDRESS").String()
 
 	InsecureSkipVerify = kingpin.Flag("insecure-skip-verify", "Skip TLS certificate verification").Envar("INSECURE_SKIP_VERIFY").Default("false").Bool()
+	CAFile             = kingpin.Flag("ca-file", "Path to the custom CA certificate file").Envar("CA_FILE").String()
 
 	CollectKubernetesEvents = kingpin.Flag("collect-kubernetes-events", "Collect and forward Kubernetes events").Envar("COLLECT_KUBERNETES_EVENTS").Default("true").Bool()
 

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -1,6 +1,9 @@
 package flags
 
 import (
+	"os"
+	"strings"
+
 	"github.com/alecthomas/kingpin/v2"
 	"k8s.io/klog"
 )
@@ -34,6 +37,10 @@ var (
 )
 
 func init() {
+	if strings.HasSuffix(os.Args[0], ".test") {
+		return
+	}
+
 	kingpin.HelpFlag.Short('h').Hidden()
 	kingpin.Parse()
 

--- a/k8s/event.go
+++ b/k8s/event.go
@@ -22,9 +22,7 @@ func NewEventsLogger() *EventsLogger {
 	opts := []otlploghttp.Option{
 		otlploghttp.WithEndpointURL((*flags.CorootURL).JoinPath("/v1/logs").String()),
 		otlploghttp.WithHeaders(common.AuthHeaders(*flags.APIKey)),
-	}
-	if *flags.InsecureSkipVerify {
-		opts = append(opts, otlploghttp.WithInsecure())
+		otlploghttp.WithTLSClientConfig(common.TlsConfig()),
 	}
 	exporter, _ := otlploghttp.New(context.Background(), opts...)
 	batcher := sdk.NewBatchProcessor(exporter)

--- a/metrics/scraper.go
+++ b/metrics/scraper.go
@@ -42,7 +42,10 @@ func (ms *Metrics) runScraper() error {
 			RemoteTimeout: model.Duration(RemoteWriteTimeout),
 			QueueConfig:   config.DefaultQueueConfig,
 			HTTPClientConfig: promCommon.HTTPClientConfig{
-				TLSConfig: promCommon.TLSConfig{InsecureSkipVerify: *flags.InsecureSkipVerify},
+				TLSConfig: promCommon.TLSConfig{
+					InsecureSkipVerify: *flags.InsecureSkipVerify,
+					CAFile:             *flags.CAFile,
+				},
 			},
 		},
 	)

--- a/profiles/profiles.go
+++ b/profiles/profiles.go
@@ -3,7 +3,6 @@ package profiles
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -55,7 +54,7 @@ func NewProfiles() *Profiles {
 		scrapeTimeout:  *flags.ProfilesScrapeTimeout,
 		httpClient: &http.Client{
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: *flags.InsecureSkipVerify},
+				TLSClientConfig: common.TlsConfig(),
 			},
 		},
 		prevCache: map[ProfileKey]map[uint64]int64{},

--- a/schema/emitter/emitter.go
+++ b/schema/emitter/emitter.go
@@ -22,9 +22,7 @@ func NewChangeEmitter() *ChangeEmitter {
 	opts := []otlploghttp.Option{
 		otlploghttp.WithEndpointURL((*flags.CorootURL).JoinPath("/v1/logs").String()),
 		otlploghttp.WithHeaders(common.AuthHeaders(*flags.APIKey)),
-	}
-	if *flags.InsecureSkipVerify {
-		opts = append(opts, otlploghttp.WithInsecure())
+		otlploghttp.WithTLSClientConfig(common.TlsConfig()),
 	}
 	exporter, _ := otlploghttp.New(context.Background(), opts...)
 	batcher := sdk.NewBatchProcessor(exporter)


### PR DESCRIPTION
As we have enabled TLS support in coroot application, at present there is no way to validate the server certificate when cluster-agent tries to connect to coroot endpoint.

One option is to use flag INSECURE_SKIP_VERIFY , but this is a not so secure workaround

I have added a new env var CA_FILE, on specifiying the crt path, which will be used to validate cert